### PR TITLE
Release vehicle-registry-api v0.2.0 (with hotfix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vehicle-registry-api",
-    "version": "0.1.0-dev",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vehicle-registry-api",
-            "version": "0.1.0-dev",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
                 "body-parser": "^1.20.3",

--- a/src/app/app.validation.test.ts
+++ b/src/app/app.validation.test.ts
@@ -4,6 +4,7 @@
 
 import express from "express";
 import { StatusCodes } from "http-status-codes";
+import { objToString } from "@/utils";
 import request from "supertest";
 import { z } from "zod";
 import { validateBody } from "./app.validation";
@@ -31,11 +32,14 @@ describe("validateBody Middleware", () => {
 
         expect(response.status).toBe(StatusCodes.BAD_REQUEST);
         expect(response.body).toEqual({
-            errors: [
-                { path: "number", message: "Required" },
-                { path: "brand", message: "Required" },
-                { path: "model", message: "Required" },
-            ],
+            error: {
+                type: "ValidationError",
+                msg: objToString([
+                    { path: "number", message: "Required" },
+                    { path: "brand", message: "Required" },
+                    { path: "model", message: "Required" },
+                ]),
+            },
         });
     });
 


### PR DESCRIPTION
It updates a test that was missing at `app.validation.test.ts` after standardizing the validation error response. It fixes the release of PR #8.