### PR TITLE
Update not found vehicle tests and remove string conversion in validation error

### DIFF
--- a/src/app/app.error.ts
+++ b/src/app/app.error.ts
@@ -101,7 +101,7 @@ export const respondHttpError = (res: Response) => (error: unknown) => {
 };
 
 export function errorHandler(
-    err: Error,
+    err: AppError,
     req: Request,
     res: Response,
     next: NextFunction,

--- a/src/app/app.validation.ts
+++ b/src/app/app.validation.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/tobiasbriones/vehicle-registry-api
 
-import { objToString } from "@/utils";
 import { validationError } from "@app/app.error";
 import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
@@ -21,7 +20,7 @@ export const validateBody = <T extends ZodSchema>(schema: T) => {
                 path: err.path.join("."),
                 message: err.message,
             }));
-            const error = validationError(objToString(errors));
+            const error = validationError(errors);
 
             res.status(StatusCodes.BAD_REQUEST).json(error);
             return;

--- a/src/app/vehicle/vehicle.controller.test.ts
+++ b/src/app/vehicle/vehicle.controller.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/tobiasbriones/vehicle-registry-api
 
+import { notFoundError } from "@app/app.error";
 import express from "express";
 import { StatusCodes } from "http-status-codes";
 import { createMocks } from "node-mocks-http";
@@ -81,11 +82,22 @@ describe("VehicleController", () => {
     test("GET /vehicles/:number - Not Found", async () => {
         mockVehicleService.read.mockResolvedValue(null);
 
-        const response = await request(app).get("/vehicles/VIN-999");
+        const { req, res } = createMocks({ params: { number: "VIN-999" } });
+        const next = jest.fn();
 
-        expect(response.status).toBe(StatusCodes.NOT_FOUND);
-        expect(response.body)
-            .toEqual({ error: "Vehicle number not found: VIN-999" });
+        // Mock `res.status` and `res.json` to be jest mock functions
+        res.status = jest.fn(() => res);
+        res.json = jest.fn(() => res);
+
+        await vehicleController.read(req, res, next);
+
+        expect(next)
+            .toHaveBeenCalledWith(
+                notFoundError(`Vehicle number not found: VIN-999`),
+            );
+
+        expect(res.status).not.toHaveBeenCalled();
+        expect(res.json).not.toHaveBeenCalled();
     });
 
     test("GET /vehicles - Success", async () => {
@@ -120,12 +132,25 @@ describe("VehicleController", () => {
     test("PUT /vehicles/:number - Not Found", async () => {
         mockVehicleService.update.mockResolvedValue(null);
 
-        const response = await request(app)
-            .put("/vehicles/VIN-999")
-            .send({ brand: "Toyota", model: "Corolla" });
+        const { req, res } = createMocks({
+            params: { number: "VIN-999" },
+            body: { brand: "Toyota", model: "Corolla" },
+        });
+        const next = jest.fn();
 
-        expect(response.status).toBe(StatusCodes.NOT_FOUND);
-        expect(response.body).toEqual({ error: "Vehicle not found: VIN-999" });
+        // Mock `res.status` and `res.json` to be jest mock functions
+        res.status = jest.fn(() => res);
+        res.json = jest.fn(() => res);
+
+        await vehicleController.update(req, res, next);
+
+        expect(next)
+            .toHaveBeenCalledWith(
+                notFoundError(`Vehicle not found: VIN-999`),
+            );
+
+        expect(res.status).not.toHaveBeenCalled();
+        expect(res.json).not.toHaveBeenCalled();
     });
 
     test("DELETE /vehicles/:number - Success", async () => {
@@ -141,9 +166,21 @@ describe("VehicleController", () => {
     test("DELETE /vehicles/:number - Not Found", async () => {
         mockVehicleService.delete.mockResolvedValue(false);
 
-        const response = await request(app).delete("/vehicles/VIN-999");
+        const { req, res } = createMocks({ params: { number: "VIN-999" }, });
+        const next = jest.fn();
 
-        expect(response.status).toBe(StatusCodes.NOT_FOUND);
-        expect(response.body).toEqual({ error: "Vehicle not found: VIN-999" });
+        // Mock `res.status` and `res.json` to be jest mock functions
+        res.status = jest.fn(() => res);
+        res.json = jest.fn(() => res);
+
+        await vehicleController.delete(req, res, next);
+
+        expect(next)
+            .toHaveBeenCalledWith(
+                notFoundError(`Vehicle not found: VIN-999`),
+            );
+
+        expect(res.status).not.toHaveBeenCalled();
+        expect(res.json).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
There were no tests that I did not update after using `next` to forward the Express.js error, so these tests must check for the error on `next` instead of direct response and call the controller method directly with request and repose mocks.

Errors must be responded to as the original objects to not lose information.