### PR TITLE
Release vehicle-registry-api v0.5.0

### DIFF
--- a/docs/app/vehicle-logs.md
+++ b/docs/app/vehicle-logs.md
@@ -44,7 +44,18 @@ Creates a new vehicle log.
       ```json
       {
         "id": "integer",
-        "vehicleNumber": "string",
+        "vehicle": {
+          "number": "string",
+          "brand": "string",
+          "model": "string"  
+        },
+        "driver": {
+          "licenseId": "string",
+          "firstName": "string",
+          "surname": "string",
+          "secondName": "string | null",
+          "secondSurname": "string | null"
+        },
         "driverLicenseId": "string",
         "logType": "string",
         "timestamp": "string",
@@ -55,8 +66,14 @@ Creates a new vehicle log.
       ```json
       {
         "id": 1,
-        "vehicleNumber": "ABC123",
-        "driverLicenseId": "D123456",
+         "vehicle": { "number": "VIN-010", "brand": "Hyundai", "model": "Elantra" },
+         "driver": {
+           "licenseId": "D890123",
+           "firstName": "Olivia",
+           "surname": "Green",
+           "secondName": null,
+           "secondSurname": "Harris"
+        },
         "logType": "entry",
         "timestamp": "2024-12-01T10:00:00Z",
         "mileageInKilometers": 10000
@@ -151,8 +168,18 @@ Retrieves a specific vehicle log by ID.
       ```json
       {
         "id": "integer",
-        "vehicleNumber": "string",
-        "driverLicenseId": "string",
+        "vehicle": {
+          "number": "string",
+          "brand": "string",
+          "model": "string"  
+        },
+        "driver": {
+          "licenseId": "string",
+          "firstName": "string",
+          "surname": "string",
+          "secondName": "string | null",
+          "secondSurname": "string | null"
+        },
         "logType": "string",
         "timestamp": "string",
         "mileageInKilometers": "integer"
@@ -162,8 +189,14 @@ Retrieves a specific vehicle log by ID.
       ```json
       {
         "id": 1,
-        "vehicleNumber": "ABC123",
-        "driverLicenseId": "D123456",
+        "vehicle": { "number": "VIN-010", "brand": "Hyundai", "model": "Elantra" },
+        "driver": {
+          "licenseId": "D890123",
+          "firstName": "Olivia",
+          "surname": "Green",
+          "secondName": null,
+          "secondSurname": "Harris"
+        },
         "logType": "entry",
         "timestamp": "2024-12-01T10:00:00Z",
         "mileageInKilometers": 10000

--- a/docs/app/vehicle-logs.md
+++ b/docs/app/vehicle-logs.md
@@ -236,8 +236,18 @@ Retrieves all vehicle logs with optional filters.
       [
         {
           "id": "integer",
-          "vehicleNumber": "string",
-          "driverLicenseId": "string",
+          "vehicle": {
+            "number": "string",
+            "brand": "string",
+            "model": "string"  
+          },
+          "driver": {
+            "licenseId": "string",
+            "firstName": "string",
+            "surname": "string",
+            "secondName": "string | null",
+            "secondSurname": "string | null"
+          },
           "logType": "string",
           "timestamp": "string",
           "mileageInKilometers": "integer"
@@ -248,9 +258,19 @@ Retrieves all vehicle logs with optional filters.
       ```json
       [
         {
-          "id": 1,
-          "vehicleNumber": "ABC123",
-          "driverLicenseId": "DL123456",
+          "id": 48,
+          "vehicle": {
+            "number": "VIN-010",
+            "brand": "Hyundai",
+            "model": "Elantra"
+          },
+          "driver": {
+            "licenseId": "D890123",
+            "firstName": "Olivia",
+            "surname": "Green",
+            "secondName": null,
+            "secondSurname": "Harris"
+          },
           "logType": "entry",
           "timestamp": "2024-12-01T10:00:00Z",
           "mileageInKilometers": 10000

--- a/docs/app/vehicle-logs.md
+++ b/docs/app/vehicle-logs.md
@@ -45,7 +45,7 @@ Creates a new vehicle log.
       {
         "id": "integer",
         "vehicleNumber": "string",
-        "driverFullName": "string",
+        "driverLicenseId": "string",
         "logType": "string",
         "timestamp": "string",
         "mileageInKilometers": "integer"
@@ -56,7 +56,7 @@ Creates a new vehicle log.
       {
         "id": 1,
         "vehicleNumber": "ABC123",
-        "driverFullName": "John Doe",
+        "driverLicenseId": "D123456",
         "logType": "entry",
         "timestamp": "2024-12-01T10:00:00Z",
         "mileageInKilometers": 10000
@@ -152,7 +152,7 @@ Retrieves a specific vehicle log by ID.
       {
         "id": "integer",
         "vehicleNumber": "string",
-        "driverFullName": "string",
+        "driverLicenseId": "string",
         "logType": "string",
         "timestamp": "string",
         "mileageInKilometers": "integer"
@@ -163,7 +163,7 @@ Retrieves a specific vehicle log by ID.
       {
         "id": 1,
         "vehicleNumber": "ABC123",
-        "driverFullName": "John Doe",
+        "driverLicenseId": "D123456",
         "logType": "entry",
         "timestamp": "2024-12-01T10:00:00Z",
         "mileageInKilometers": 10000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vehicle-registry-api",
-    "version": "0.4.0",
+    "version": "0.4.0-dev",
     "description": "Backend API for a vehicle registration web app that allows entrance and leave.",
     "main": "index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vehicle-registry-api",
-    "version": "0.4.0-dev",
+    "version": "0.5.0",
     "description": "Backend API for a vehicle registration web app that allows entrance and leave.",
     "main": "index.js",
     "type": "module",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -29,7 +29,11 @@ export function newAppConfig(): AppConfig {
     const { dbPool } = newAppDatabase();
     const vehicleService = newVehicleService(dbPool);
     const driverService = newDriverService(dbPool);
-    const vehicleLogService = newVehicleLogService(dbPool, driverService);
+    const vehicleLogService = newVehicleLogService(
+        dbPool,
+        vehicleService,
+        driverService,
+    );
 
     return {
         vehicleController: newVehicleController(vehicleService),

--- a/src/app/driver/driver.ts
+++ b/src/app/driver/driver.ts
@@ -23,6 +23,22 @@ export const driverFullName = (
     .filter(Boolean) // Remove undefined or falsy values
     .join(" ");
 
+/**
+ * Defines the SQL JSON arguments of the Driver model passed to the
+ * `json_build_object` PSQL function when fetching a Driver record as a
+ * composed object.
+ *
+ * The underlying SQL where these args will be placed must use the `driver`
+ * and `name` variables to join the `driver` and `driver_name` tables.
+ */
+export const driverSqlJsonArgs: string = `
+    'licenseId', driver.license_id,
+    'firstName', COALESCE(name.first_name, 'N/A'),
+    'surname', COALESCE(name.surname, 'N/A'),
+    'secondName', name.second_name,
+    'secondSurname', name.second_surname
+`;
+
 export const driverRegistrationSchema = z.object({
     licenseId: z
         .string()

--- a/src/app/vehicle-log/vehicle-log.controller.test.ts
+++ b/src/app/vehicle-log/vehicle-log.controller.test.ts
@@ -53,8 +53,16 @@ describe("VehicleLogController", () => {
 
                 const mockLog: VehicleLog = {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "Joe Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL456",
+                        firstName: "John",
+                        surname: "Doe",
+                    },
                     logType: "entry",
                     mileageInKilometers: 20,
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
@@ -81,8 +89,16 @@ describe("VehicleLogController", () => {
         it("should return a vehicle log when found", async () => {
             const mockLog: VehicleLog = {
                 id: 1,
-                vehicleNumber: "VIN-123",
-                driverFullName: "Joe Doe",
+                vehicle: {
+                    number: "VIN-123",
+                    brand: "Hyundai",
+                    model: "Elantra",
+                },
+                driver: {
+                    licenseId: "DL456",
+                    firstName: "Joe",
+                    surname: "Doe",
+                },
                 logType: "entry",
                 mileageInKilometers: 20,
                 timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
@@ -123,8 +139,16 @@ describe("VehicleLogController", () => {
             const mockLogs: VehicleLog[] = [
                 {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "Joe Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL987",
+                        firstName: "Joe",
+                        surname: "Doe",
+                    },
                     logType: "entry",
                     mileageInKilometers: 0,
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
@@ -151,8 +175,16 @@ describe("VehicleLogController", () => {
             async () => {
                 const mockLog: VehicleLog = {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "Joe Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL987",
+                        firstName: "Joe",
+                        surname: "Smith",
+                    },
                     logType: "entry",
                     mileageInKilometers: 110,
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),

--- a/src/app/vehicle-log/vehicle-log.service.test.ts
+++ b/src/app/vehicle-log/vehicle-log.service.test.ts
@@ -305,7 +305,7 @@ describe("VehicleLogService", () => {
             expect(pool.query).toHaveBeenCalledTimes(1);
             expect(pool.query).toHaveBeenCalledWith(
                 expect.stringContaining(
-                    "WHERE ($1::VARCHAR IS NULL OR v.number = $1)"),
+                    "WHERE ($1::VARCHAR IS NULL OR vehicle.number = $1)"),
                 [
                     "VIN-123", // Filter by vehicleNumber
                     null,      // driverLicenseId is null
@@ -386,7 +386,7 @@ describe("VehicleLogService", () => {
             expect(pool.query).toHaveBeenCalledTimes(1);
             expect(pool.query).toHaveBeenCalledWith(
                 expect.stringContaining(
-                    "AND ($3::DATE IS NULL OR DATE(vl.event_timestamp) = $3)"),
+                    "AND ($3::DATE IS NULL OR DATE(log.event_timestamp) = $3)"),
                 [
                     null,         // Filter by vehicleNumber
                     null,         // driverLicenseId is null

--- a/src/app/vehicle-log/vehicle-log.service.test.ts
+++ b/src/app/vehicle-log/vehicle-log.service.test.ts
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/tobiasbriones/vehicle-registry-api
 
+import { AppError } from "@app/app.error";
+import { Driver } from "@app/driver/driver";
 import { DriverService } from "@app/driver/driver.service";
+import { VehicleService } from "@app/vehicle/vehicle.service";
 import { Pool, PoolClient } from "pg";
-import { AppError } from "src/app/app.error";
-import { Driver } from "src/app/driver/driver";
+import { Vehicle } from "@app/vehicle/vehicle";
 import {
     VehicleLog,
     VehicleLogCreateBody,
@@ -19,6 +21,7 @@ jest.mock("@app/driver/driver.service");
 describe("VehicleLogService", () => {
     let pool: jest.Mocked<Pool>;
     let client: jest.Mocked<PoolClient>;
+    let vehicleService: jest.Mocked<VehicleService>;
     let driverService: jest.Mocked<DriverService>;
     let service: VehicleLogService;
 
@@ -34,11 +37,15 @@ describe("VehicleLogService", () => {
             connect: jest.fn().mockResolvedValue(client),
         } as unknown as jest.Mocked<Pool>;
 
+        vehicleService = {
+            read: jest.fn(),
+        } as unknown as jest.Mocked<VehicleService>;
+
         driverService = {
             read: jest.fn(),
         } as unknown as jest.Mocked<DriverService>;
 
-        service = newVehicleLogService(pool, driverService);
+        service = newVehicleLogService(pool, vehicleService, driverService);
     });
 
     afterEach(() => {
@@ -52,6 +59,12 @@ describe("VehicleLogService", () => {
                 driverLicenseId: "DL456",
                 logType: "entry",
                 mileageInKilometers: 1000,
+            };
+
+            const mockVehicle: Vehicle = {
+                number: "VIN-123",
+                brand: "Hyundai",
+                model: "Elantra",
             };
 
             const mockDriver: Driver = {
@@ -105,6 +118,7 @@ describe("VehicleLogService", () => {
                     rowCount: 1,
                 }); // Insert log
 
+            vehicleService.read.mockResolvedValue(mockVehicle);
             driverService.read.mockResolvedValue(mockDriver);
 
             const result = await service.create(mockLog);
@@ -112,12 +126,12 @@ describe("VehicleLogService", () => {
             expect(client.query).toHaveBeenCalledTimes(7);
             expect(result).toEqual({
                 id: 1,
-                vehicleNumber: "VIN-123",
-                driverFullName: "John Doe",
+                vehicle: mockVehicle,
+                driver: mockDriver,
                 logType: "entry",
-                timestamp: "2024-11-27 00:18:00.755929 +00:00",
+                timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                 mileageInKilometers: 1000,
-            });
+            } as VehicleLog);
         });
 
         it("should throw an error if vehicle does not exist", async () => {
@@ -162,10 +176,22 @@ describe("VehicleLogService", () => {
 
     describe("read", () => {
         it("should return a vehicle log by ID", async () => {
+            const mockVehicle: Vehicle = {
+                number: "VIN-123",
+                brand: "Hyundai",
+                model: "Elantra",
+            };
+
+            const mockDriver: Driver = {
+                licenseId: "DL456",
+                firstName: "John",
+                surname: "Doe",
+            };
+
             const mockLog: VehicleLog = {
                 id: 1,
-                vehicleNumber: "VIN-123",
-                driverFullName: "John Doe",
+                vehicle: mockVehicle,
+                driver: mockDriver,
                 logType: "entry",
                 timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                 mileageInKilometers: 1000,
@@ -202,8 +228,16 @@ describe("VehicleLogService", () => {
             const mockLogs: VehicleLog[] = [
                 {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "John Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL456",
+                        firstName: "John",
+                        surname: "Doe",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                     mileageInKilometers: 1000,
@@ -224,16 +258,33 @@ describe("VehicleLogService", () => {
             const mockLogs: VehicleLog[] = [
                 {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "John Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL456",
+                        firstName: "John",
+                        surname: "Doe",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                     mileageInKilometers: 1000,
                 },
+
                 {
                     id: 2,
-                    vehicleNumber: "VIN-321",
-                    driverFullName: "Joe Smith",
+                    vehicle: {
+                        number: "VIN-321",
+                        brand: "Mazda",
+                        model: "CX-5",
+                    },
+                    driver: {
+                        licenseId: "DL987",
+                        firstName: "Joe",
+                        surname: "Smith",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-28 00:18:00.755929 +00:00"),
                     mileageInKilometers: 2000,
@@ -263,15 +314,24 @@ describe("VehicleLogService", () => {
                     0,         // Offset (calculated from page - 1)
                 ],
             );
+
             expect(result).toEqual([
                 {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "John Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL456",
+                        firstName: "John",
+                        surname: "Doe",
+                    },
                     logType: "entry",
-                    timestamp: new Date("2024-11-27T00:18:00.755Z"),
+                    timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                     mileageInKilometers: 1000,
-                },
+                } as VehicleLog,
             ]);
         });
 
@@ -279,16 +339,33 @@ describe("VehicleLogService", () => {
             const mockLogs: VehicleLog[] = [
                 {
                     id: 1,
-                    vehicleNumber: "VIN-123",
-                    driverFullName: "John Doe",
+                    vehicle: {
+                        number: "VIN-123",
+                        brand: "Hyundai",
+                        model: "Elantra",
+                    },
+                    driver: {
+                        licenseId: "DL456",
+                        firstName: "John",
+                        surname: "Doe",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-27 00:18:00.755929 +00:00"),
                     mileageInKilometers: 1000,
                 },
+
                 {
                     id: 2,
-                    vehicleNumber: "VIN-321",
-                    driverFullName: "Joe Smith",
+                    vehicle: {
+                        number: "VIN-321",
+                        brand: "Kia",
+                        model: "Soul",
+                    },
+                    driver: {
+                        licenseId: "DL987",
+                        firstName: "Joe",
+                        surname: "Smith",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-28 00:18:00.755929 +00:00"),
                     mileageInKilometers: 2000,
@@ -321,12 +398,20 @@ describe("VehicleLogService", () => {
             expect(result).toEqual([
                 {
                     id: 2,
-                    vehicleNumber: "VIN-321",
-                    driverFullName: "Joe Smith",
+                    vehicle: {
+                        number: "VIN-321",
+                        brand: "Kia",
+                        model: "Soul",
+                    },
+                    driver: {
+                        licenseId: "DL987",
+                        firstName: "Joe",
+                        surname: "Smith",
+                    },
                     logType: "entry",
                     timestamp: new Date("2024-11-28 00:18:00.755929 +00:00"),
                     mileageInKilometers: 2000,
-                },
+                } as VehicleLog,
             ]);
         });
     });
@@ -345,8 +430,17 @@ describe("VehicleLogService", () => {
 
             const readSpy = jest.spyOn(service, "read").mockResolvedValueOnce({
                 ...mockUpdate,
-                vehicleNumber: "VIN-123",
-                driverFullName: "John Doe",
+                vehicle: {
+                    number: "VIN-123",
+                    brand: "Hyundai",
+                    model: "Elantra",
+                },
+
+                driver: {
+                    licenseId: "DL456",
+                    firstName: "John",
+                    surname: "Doe",
+                },
                 timestamp: new Date("2024-11-28 00:18:00.755929 +00:00"),
             });
 

--- a/src/app/vehicle-log/vehicle-log.service.ts
+++ b/src/app/vehicle-log/vehicle-log.service.ts
@@ -331,11 +331,11 @@ export const newVehicleLogService = (
         const offset = (page - 1) * limit;
         const query = `
             SELECT vl.id,
-                   v.number     AS vehicle_number,
-                   d.license_id AS driver_license_id,
-                   vl.event_type,
-                   vl.event_timestamp,
-                   vl.mileage
+                   v.number           AS "vehicleNumber",
+                   d.license_id       AS "driverLicenseId",
+                   vl.event_type      AS "eventType",
+                   vl.event_timestamp AS "timestamp",
+                   vl.mileage         AS "mileage"
             FROM vehicle_log vl
                      JOIN vehicle v ON vl.vehicle_id = v.id
                      JOIN driver d ON vl.driver_id = d.id

--- a/src/app/vehicle-log/vehicle-log.service.ts
+++ b/src/app/vehicle-log/vehicle-log.service.ts
@@ -111,7 +111,6 @@ export const newVehicleLogService = (
                                ELSE FALSE -- New mileage is less than the last mileage
                                END                            AS "isValid",
                            (SELECT mileage FROM last_mileage) AS "lastMileage"
-
                 `,
                 [ vehicleId, mileageInKilometers ],
             )
@@ -298,7 +297,7 @@ export const newVehicleLogService = (
                 driver,
                 logType,
                 timestamp: new Date(result.timestamp),
-                mileageInKilometers: mileageInKilometers,
+                mileageInKilometers,
             } as VehicleLog;
         }
         catch (error) {

--- a/src/app/vehicle-log/vehicle-log.service.ts
+++ b/src/app/vehicle-log/vehicle-log.service.ts
@@ -9,7 +9,7 @@ import {
     rejectInternalError,
     rejectReferenceNotFoundError,
 } from "@app/app.error";
-import { driverFullName } from "@app/driver/driver";
+import { driverSqlJsonArgs } from "@app/driver/driver";
 import { DriverService } from "@app/driver/driver.service";
 import {
     driverNotFoundInfo,
@@ -17,6 +17,8 @@ import {
     incorrectMileageInfo,
     vehicleNotFoundInfo,
 } from "@app/vehicle-log/vehicle-log.error";
+import { vehicleSqlJsonArgs } from "@app/vehicle/vehicle";
+import { VehicleService } from "@app/vehicle/vehicle.service";
 import { withError } from "@log/log";
 import { Pool, PoolClient, QueryResult } from "pg";
 import {
@@ -48,6 +50,7 @@ export type VehicleLogService = {
 
 export const newVehicleLogService = (
     pool: Pool,
+    vehicleService: VehicleService,
     driverService: DriverService,
 ): VehicleLogService => ({
     async create(log) {
@@ -93,21 +96,21 @@ export const newVehicleLogService = (
         ): Promise<MileageIsValidResult> => client
             .query(
                 `
-                WITH last_mileage AS (SELECT mileage
-                                      FROM vehicle_log
-                                      WHERE vehicle_id = $1
-                                      ORDER BY event_timestamp DESC
-                                      LIMIT 1)
-                SELECT CASE
-                           WHEN NOT EXISTS (SELECT 1 FROM last_mileage)
-                               THEN TRUE  -- No previous records, valid to start at any mileage
-                           WHEN $2 = 0
-                                THEN TRUE -- Mileage resets are valid
-                           WHEN $2 >= (SELECT mileage FROM last_mileage)
-                               THEN TRUE  -- New mileage is greater or equal to the last mileage
-                           ELSE FALSE     -- New mileage is less than the last mileage
-                           END                            AS "isValid",
-                       (SELECT mileage FROM last_mileage) AS "lastMileage"
+                    WITH last_mileage AS (SELECT mileage
+                                          FROM vehicle_log
+                                          WHERE vehicle_id = $1
+                                          ORDER BY event_timestamp DESC
+                                          LIMIT 1)
+                    SELECT CASE
+                               WHEN NOT EXISTS (SELECT 1 FROM last_mileage)
+                                   THEN TRUE -- No previous records, valid to start at any mileage
+                               WHEN $2 = 0
+                                   THEN TRUE -- Mileage resets are valid
+                               WHEN $2 >= (SELECT mileage FROM last_mileage)
+                                   THEN TRUE -- New mileage is greater or equal to the last mileage
+                               ELSE FALSE -- New mileage is less than the last mileage
+                               END                            AS "isValid",
+                           (SELECT mileage FROM last_mileage) AS "lastMileage"
 
                 `,
                 [ vehicleId, mileageInKilometers ],
@@ -128,24 +131,24 @@ export const newVehicleLogService = (
         ): Promise<EventIsValidResult> => client
             .query(
                 `
-                WITH last_event AS (SELECT event_type
-                                    FROM vehicle_log
-                                    WHERE vehicle_id = $1
-                                    ORDER BY event_timestamp DESC
-                                    LIMIT 1)
-                SELECT CASE
-                           WHEN NOT EXISTS (SELECT 1 FROM last_event)
-                               THEN TRUE -- No previous records, valid to start with any event
-                           WHEN $2 = 'entry' AND
-                                (SELECT event_type FROM last_event) = 'exit'
-                               THEN TRUE -- Last event was 'exit', current can be 'entry'
-                           WHEN $2 = 'exit' AND
-                                (SELECT event_type FROM last_event) =
-                                'entry'
-                               THEN TRUE -- Last event was 'entry', current can be 'exit'
-                           ELSE FALSE -- Invalid: Repeating the same event or invalid transition
-                           END                             AS "isValid",
-                       (SELECT event_type FROM last_event) AS "lastEvent";
+                    WITH last_event AS (SELECT event_type
+                                        FROM vehicle_log
+                                        WHERE vehicle_id = $1
+                                        ORDER BY event_timestamp DESC
+                                        LIMIT 1)
+                    SELECT CASE
+                               WHEN NOT EXISTS (SELECT 1 FROM last_event)
+                                   THEN TRUE -- No previous records, valid to start with any event
+                               WHEN $2 = 'entry' AND
+                                    (SELECT event_type FROM last_event) = 'exit'
+                                   THEN TRUE -- Last event was 'exit', current can be 'entry'
+                               WHEN $2 = 'exit' AND
+                                    (SELECT event_type FROM last_event) =
+                                    'entry'
+                                   THEN TRUE -- Last event was 'entry', current can be 'exit'
+                               ELSE FALSE -- Invalid: Repeating the same event or invalid transition
+                               END                             AS "isValid",
+                           (SELECT event_type FROM last_event) AS "lastEvent";
                 `,
                 [ vehicleId, logType ],
             )
@@ -259,7 +262,16 @@ export const newVehicleLogService = (
 
             await client.query("COMMIT");
 
-            // Read driver full name to return the final record
+            // Read vehicle to return the final record
+            const vehicle = await vehicleService.read(vehicleNumber);
+
+            if (vehicle === null) {
+                throw new Error(
+                    "Fail to read vehicle after registering this vehicle log.",
+                );
+            }
+
+            // Read driver to return the final record
             const driver = await driverService.read(driverLicenseId);
 
             if (driver === null) {
@@ -282,10 +294,10 @@ export const newVehicleLogService = (
 
             return {
                 id: result.id,
-                vehicleNumber,
-                driverFullName: driverFullName(driver),
+                vehicle,
+                driver,
                 logType,
-                timestamp: result.timestamp,
+                timestamp: new Date(result.timestamp),
                 mileageInKilometers: mileageInKilometers,
             } as VehicleLog;
         }
@@ -301,14 +313,19 @@ export const newVehicleLogService = (
     async read(id) {
         const query = `
             SELECT log.id,
-                   vehicle.number      AS "vehicleNumber",
-                   driver.license_id   AS "driverFullName",
+                   json_build_object(${ vehicleSqlJsonArgs })
+                                       AS vehicle,
+
+                   json_build_object(${ driverSqlJsonArgs })
+                                       AS driver,
+
                    log.event_type      AS "logType",
                    log.event_timestamp AS "timestamp",
                    log.mileage         AS "mileageInKilometers"
             FROM vehicle_log log
                      INNER JOIN vehicle ON log.vehicle_id = vehicle.id
                      INNER JOIN driver ON log.driver_id = driver.id
+                     LEFT JOIN driver_name name ON driver.id = name.driver_id
             WHERE log.id = $1;
         `;
 
@@ -349,9 +366,10 @@ export const newVehicleLogService = (
         const params = [
             vehicleNumber || null,
             driverLicenseId || null,
-            date ? date.toISOString().split("T")[0] : null, // Convert date to YYYY-MM-DD
+            date ? date.toISOString().split("T")[0] : null, // Convert date to
+                                                            // YYYY-MM-DD
             limit,
-            offset
+            offset,
         ];
 
         const handleError = (reason: unknown) =>

--- a/src/app/vehicle-log/vehicle-log.service.ts
+++ b/src/app/vehicle-log/vehicle-log.service.ts
@@ -347,19 +347,25 @@ export const newVehicleLogService = (
     async readAll(limit, page, { vehicleNumber, driverLicenseId, date }) {
         const offset = (page - 1) * limit;
         const query = `
-            SELECT vl.id,
-                   v.number           AS "vehicleNumber",
-                   d.license_id       AS "driverLicenseId",
-                   vl.event_type      AS "eventType",
-                   vl.event_timestamp AS "timestamp",
-                   vl.mileage         AS "mileage"
-            FROM vehicle_log vl
-                     JOIN vehicle v ON vl.vehicle_id = v.id
-                     JOIN driver d ON vl.driver_id = d.id
-            WHERE ($1::VARCHAR IS NULL OR v.number = $1)
-              AND ($2::VARCHAR IS NULL OR d.license_id = $2)
-              AND ($3::DATE IS NULL OR DATE(vl.event_timestamp) = $3)
-            ORDER BY vl.event_timestamp DESC
+            SELECT log.id,
+                   json_build_object(${ vehicleSqlJsonArgs })
+                                       AS vehicle,
+
+                   json_build_object(${ driverSqlJsonArgs })
+                                       AS driver,
+
+                   log.event_type      AS "logType",
+                   log.event_timestamp AS "timestamp",
+                   log.mileage         AS "mileageInKilometers"
+            FROM vehicle_log log
+                     INNER JOIN vehicle ON log.vehicle_id = vehicle.id
+                     INNER JOIN driver ON log.driver_id = driver.id
+                     LEFT JOIN driver_name name ON driver.id = name.driver_id
+
+            WHERE ($1::VARCHAR IS NULL OR vehicle.number = $1)
+              AND ($2::VARCHAR IS NULL OR driver.license_id = $2)
+              AND ($3::DATE IS NULL OR DATE(log.event_timestamp) = $3)
+            ORDER BY log.event_timestamp DESC
             LIMIT $4 OFFSET $5;
         `;
 

--- a/src/app/vehicle-log/vehicle-log.ts
+++ b/src/app/vehicle-log/vehicle-log.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // This file is part of https://github.com/tobiasbriones/vehicle-registry-api
 
+import { Driver } from "@app/driver/driver";
+import { Vehicle } from "@app/vehicle/vehicle";
 import { z } from "zod";
 
 export type VehicleLogType = "entry" | "exit";
@@ -11,8 +13,8 @@ export type VehicleLogType = "entry" | "exit";
  */
 export type VehicleLog = {
     id: number,
-    vehicleNumber: string,
-    driverFullName: string,
+    vehicle: Vehicle,
+    driver: Driver,
     logType: VehicleLogType;
     timestamp: Date;
     mileageInKilometers: number;

--- a/src/app/vehicle/vehicle.ts
+++ b/src/app/vehicle/vehicle.ts
@@ -18,6 +18,20 @@ export type Vehicle = {
     model: string,
 }
 
+/**
+ * Defines the SQL JSON arguments of the Vehicle model passed to the
+ * `json_build_object` PSQL function when fetching a Vehicle record as a
+ * composed object.
+ *
+ * The underlying SQL where these args will be placed must use the `vehicle`
+ * variable to join the `vehicle` table.
+ */
+export const vehicleSqlJsonArgs: string = `
+    'number', vehicle.number,
+    'brand', vehicle.brand,
+    'model', vehicle.model
+`;
+
 export const vehicleRegistrationSchema = z.object({
     number: z.string().max(20).trim().min(1),
     brand: z.string().max(100).trim().min(1),


### PR DESCRIPTION
It responds with complete records in the /logs endpoints.

The API should respond with complete records (by fetching the FKs) instead of just low-level IDs, like `vehicleNumber` or `driverLicenseId`.